### PR TITLE
Added a better randomizer implementation for rand-int

### DIFF
--- a/src/dnddice/core.clj
+++ b/src/dnddice/core.clj
@@ -1,8 +1,8 @@
 (ns dnddice.core
   (:require [dnddice.parser :as parser]))
 
-(defn apply-modifier [{:keys [modifier]} roll-outcome] 
-  (if modifier 
+(defn apply-modifier [{:keys [modifier]} roll-outcome]
+  (if modifier
     (let [operator (case (:operator modifier)
                      "+" +
                      "-" -
@@ -18,20 +18,20 @@
 (defn modifier-str [{:keys [modifier]}]
   (if modifier (str (:operator modifier) (:value modifier))))
 
-(defn roll-die 
+(defn roll-die
   "Rolls a die of n sides."
-  [sides] 
-  (+ (rand-int sides) 1))
+  [sides]
+  (inc (mod (.nextInt (java.security.SecureRandom.)) sides)))
 
-(defn parse-roll 
+(defn parse-roll
   "Creates a roll map (e.g. {:die-count 5 :sides 20 :modifier {:operator '-'
   :value 1}}) from a Dungeons and Dragons die roll string (e.g. '1d20'). If
   the input-str is not a valid DnD roll an IllegalArgumentException is
   thrown."
-  [input-str] 
+  [input-str]
   (parser/parse-roll input-str))
 
-(defn perform-roll 
+(defn perform-roll
   "Performs a Dungeons and Dragons roll. Returns a map with the roll, the
   outcome of the roll and the sum of the outcome."
   [roll]


### PR DESCRIPTION
rand-int uses java.util.Random to generate a random number. For dice rolling, maybe not such a big deal but I think the java.security.SecureRandom implementation will promote better random number generation. 
